### PR TITLE
Add Geocoder gem for distance calculations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,13 @@ ruby '2.4.0'
 
 gem 'sinatra', '~> 1.4.7'  # Our chosen web app framework
 gem "sinatra-activerecord", '2.0.13' # Our chosen ORM for any SQL database
-gem 'thin',    '~> 1.7.0'  # Basic web server
-gem 'rerun',   '~> 0.11.0' # Out-of-process reloader for Ruby apps
-gem 'rake',    '~> 12.0.0' # Make-like build tool, but easier-to-use
-gem 'rack',    '~> 1.6.5'  # HTTP handling
-gem 'json',    '~> 2.1.0'  # JSON handling
-gem 'pg',      '0.20.0'    # Avoid upgrading database version without testing
+gem 'thin',     '~> 1.7.0'  # Basic web server
+gem 'rerun',    '~> 0.11.0' # Out-of-process reloader for Ruby apps
+gem 'rake',     '~> 12.0.0' # Make-like build tool, but easier-to-use
+gem 'rack',     '~> 1.6.5'  # HTTP handling
+gem 'json',     '~> 2.1.0'  # JSON handling
+gem 'pg',       '0.20.0'    # Avoid upgrading database version without testing
+gem 'geocoder', '~>1.4.4'   # GPS coordinate and location handling
 
 group :development, :test do
   gem 'pry',            '~> 0.10.4'   # Ruby debugger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     daemons (1.2.4)
     eventmachine (1.2.3)
     ffi (1.9.18)
+    geocoder (1.4.4)
     i18n (0.8.1)
     json (2.1.0)
     listen (3.1.5)
@@ -92,6 +93,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print (~> 1.7.0)
+  geocoder (~> 1.4.4)
   json (~> 2.1.0)
   minitest (~> 5.10.1)
   minitest-reporters (~> 1.1.14)

--- a/lib/assassin/server.rb
+++ b/lib/assassin/server.rb
@@ -51,6 +51,8 @@ module Assassin
     # Centralize database config details in one place
     register Sinatra::ActiveRecordExtension
     set :database_file, 'database.yml'
+    # Use kilometers for our calculations for easier conversion
+    Geocoder.configure(units: :km)
 
     get '/hello_world' do
       'Hello world'

--- a/lib/assassin/server.rb
+++ b/lib/assassin/server.rb
@@ -6,8 +6,9 @@
 #
 # https://stackoverflow.com/questions/6766482/how-to-organize-models-in-sinatra
 
-require "sinatra/base"
-require "sinatra/activerecord"
+require 'sinatra/base'
+require 'sinatra/activerecord'
+require 'geocoder'
 
 # TODO: Move models into separate files
 class Player < ActiveRecord::Base


### PR DESCRIPTION
We can use [`geocoder`](http://www.rubygeocoder.com/) to [calculate the distance](https://github.com/alexreisner/geocoder/blob/master/lib/geocoder/calculations.rb#L84) between two points on Earth's surface (our two players, assassin and target). 

To use kilometers by default: `Geocoder.configure(units: :km)`

And an example computation looks like this: `Geocoder::Calculations.distance_between([37.7465497,-122.4849806], [34.057087, -117.968212])` (it can take an options hash for the units to use, e.g., `distance_between([xxx,xxx], [xxx,xxx], units: :mi`)