### PR TITLE
Update leave route to handle end game

### DIFF
--- a/lib/assassin/server.rb
+++ b/lib/assassin/server.rb
@@ -187,7 +187,7 @@ module Assassin
           player.destroy
           TargetAssignment.where(player_id: player.id).destroy_all
         end
-          status 200
+        status 200
       else
         status 404
       end

--- a/lib/assassin/server.rb
+++ b/lib/assassin/server.rb
@@ -164,12 +164,16 @@ module Assassin
       username = parsed_request_body['username']
       player = Player.find_by(username: username)
       if player
-        if player.role == "GameMaster"
-          Game.first.destroy
-          TargetAssignment.delete_all
+        # Leaving the game while the game is setting up
+        if Game.first.status == "SettingUp"
+          if player.role == "GameMaster"
+            Game.first.destroy
+            TargetAssignment.delete_all
+          else
+            player.destroy
+          end
         else
-          # Player (not GM) leaves the game: 
-          # Assign Player's target to Player's hunter
+          # Leaving the game while game is in play
           player_hunter = Player.find_by(id: TargetAssignment.reverse_lookup_assignment(player.id))
           player_target = Player.find_by(id: TargetAssignment.lookup_assignment(player.id))
           TargetAssignment.update_assignment(player_hunter.id, player_target.id)

--- a/lib/assassin/server.rb
+++ b/lib/assassin/server.rb
@@ -172,7 +172,7 @@ module Assassin
           # Assign Player's target to Player's hunter
           player_hunter = Player.find_by(id: TargetAssignment.reverse_lookup_assignment(player.id))
           player_target = Player.find_by(id: TargetAssignment.lookup_assignment(player.id))
-          TargetAssignment.update(player_hunter.id, player_target.id)
+          TargetAssignment.update_assignment(player_hunter.id, player_target.id)
 
           # Change Game status if there is one person alive = end condition
           if player_target.id == player_hunter.id


### PR DESCRIPTION
When non-GM player's leave, their target assignments are updating accordingly. Also, it is now possible to win the game if everyone else leaves.