### PR TITLE
Create /game/end route for resetting game state

### DIFF
--- a/assassin-server-insomnia-workspace.json
+++ b/assassin-server-insomnia-workspace.json
@@ -1,13 +1,13 @@
 {
 	"_type": "export",
 	"__export_format": 3,
-	"__export_date": "2017-05-30T05:27:03.156Z",
+	"__export_date": "2017-05-30T23:24:27.588Z",
 	"__export_source": "insomnia.desktop.app:v5.1.1",
 	"resources": [
 		{
 			"_id": "wrk_50c022b5e58947818d5160435e281e3e",
 			"parentId": null,
-			"modified": 1496120405328,
+			"modified": 1496179068713,
 			"created": 1495048230912,
 			"name": "Assassin Server",
 			"description": "",
@@ -17,7 +17,7 @@
 		{
 			"_id": "env_cb36c1e29d5a45d7bb61d4bc43dfbc55",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496120405325,
+			"modified": 1496179068711,
 			"created": 1495048386379,
 			"name": "Base Environment",
 			"data": {},
@@ -26,7 +26,7 @@
 		{
 			"_id": "jar_6157dbcfb97f45e690ecaf12744aa834",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496120405323,
+			"modified": 1496179068710,
 			"created": 1495048397599,
 			"name": "Default Jar",
 			"cookies": [],
@@ -35,7 +35,7 @@
 		{
 			"_id": "req_c6e5cfe2091a4e198ac5dda3cc90916b",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496120405319,
+			"modified": 1496179068708,
 			"created": 1495048386075,
 			"url": "{{ base_url }}/hello_world",
 			"name": "hello-world",
@@ -54,7 +54,7 @@
 		{
 			"_id": "req_35ae48e46bcf4bc0b9edb1f60e1d56a1",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496120405316,
+			"modified": 1496179068706,
 			"created": 1495048465853,
 			"url": "{{ base_url }}/game/players",
 			"name": "list-players",
@@ -73,7 +73,7 @@
 		{
 			"_id": "req_81e35f81b2b04f5d8eca79cba30d5c86",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496120405313,
+			"modified": 1496179068705,
 			"created": 1495142926589,
 			"url": "{{ base_url }}/game/start",
 			"name": "start-game",
@@ -92,7 +92,7 @@
 		{
 			"_id": "req_96bf15f12a8640d5814bd33303eb53fe",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496120405310,
+			"modified": 1496179068701,
 			"created": 1495577963360,
 			"url": "{{ base_url }}/game/leave",
 			"name": "leave-game",
@@ -120,7 +120,7 @@
 		{
 			"_id": "req_912b9c15eb7b435ba6be2e3f58464377",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496121979693,
+			"modified": 1496179068699,
 			"created": 1495578552549,
 			"url": "{{ base_url }}/game/location",
 			"name": "send-location",
@@ -148,7 +148,7 @@
 		{
 			"_id": "req_885d6c1b5da346d18dc313b53c95549a",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496120405303,
+			"modified": 1496179068697,
 			"created": 1495580320908,
 			"url": "{{ base_url }}/game",
 			"name": "game-overview",
@@ -167,7 +167,7 @@
 		{
 			"_id": "req_34af30577b4a45fb87b4439e5b9c511f",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496120405301,
+			"modified": 1496179068696,
 			"created": 1495581916135,
 			"url": "{{ base_url }}/game/join",
 			"name": "join-game",
@@ -195,7 +195,7 @@
 		{
 			"_id": "req_87571919ea43412992fbb06c7ab7dcf3",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496120405300,
+			"modified": 1496179068694,
 			"created": 1495581961257,
 			"url": "{{ base_url }}/game/validate?username=kycuong",
 			"name": "validate-username",
@@ -214,7 +214,7 @@
 		{
 			"_id": "req_e4db848fd1594c91b543dad2df52f5f5",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496121995935,
+			"modified": 1496179068693,
 			"created": 1495582076942,
 			"url": "{{ base_url }}/game/target?username=kycuong",
 			"name": "get-target",
@@ -233,7 +233,7 @@
 		{
 			"_id": "req_cebbfe34dde14e898eb020a485a97e59",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496121987828,
+			"modified": 1496179068691,
 			"created": 1495751265411,
 			"url": "{{ base_url }}/game/hint?hunter=kycuong&target=bnery",
 			"name": "get-hint",
@@ -252,7 +252,7 @@
 		{
 			"_id": "req_bf412f1d3def424481af7c02b9f4382b",
 			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
-			"modified": 1496122011851,
+			"modified": 1496179073823,
 			"created": 1496121697898,
 			"url": "{{base_url}}/game/kill",
 			"name": "kill-target",
@@ -270,7 +270,35 @@
 				}
 			],
 			"authentication": {},
-			"metaSortKey": -1496121697898,
+			"metaSortKey": -1495578939377.5312,
+			"settingStoreCookies": true,
+			"settingSendCookies": true,
+			"settingDisableRenderRequestBody": false,
+			"settingEncodeUrl": true,
+			"_type": "request"
+		},
+		{
+			"_id": "req_5aad539ad6584724a7358c21b51e369f",
+			"parentId": "wrk_50c022b5e58947818d5160435e281e3e",
+			"modified": 1496185686290,
+			"created": 1496185658586,
+			"url": "{{ base_url }}/game/end",
+			"name": "end-game",
+			"method": "POST",
+			"body": {
+				"mimeType": "application/json",
+				"text": "{\n\t\"username\": \"kycuong\"\n}"
+			},
+			"parameters": [],
+			"headers": [
+				{
+					"name": "Content-Type",
+					"value": "application/json",
+					"id": "pair_a6590a6a472e440f879156a376846fb9"
+				}
+			],
+			"authentication": {},
+			"metaSortKey": -1495578552449,
 			"settingStoreCookies": true,
 			"settingSendCookies": true,
 			"settingDisableRenderRequestBody": false,
@@ -280,7 +308,7 @@
 		{
 			"_id": "env_3cef6d22df9847b58c81cc2864f98885",
 			"parentId": "env_cb36c1e29d5a45d7bb61d4bc43dfbc55",
-			"modified": 1496120405295,
+			"modified": 1496179068684,
 			"created": 1495577613860,
 			"name": "Production",
 			"data": {
@@ -291,7 +319,7 @@
 		{
 			"_id": "env_aaea9d67db794a3bbd8c75db8564695a",
 			"parentId": "env_cb36c1e29d5a45d7bb61d4bc43dfbc55",
-			"modified": 1496120405291,
+			"modified": 1496179068681,
 			"created": 1495577757641,
 			"name": "Development",
 			"data": {

--- a/lib/assassin/server.rb
+++ b/lib/assassin/server.rb
@@ -324,13 +324,17 @@ module Assassin
 
       # Verify that this is the last player standing
       if player &&
-         player.id == TargetAssignment.lookup_assignment(player.id) &&
-         player.status == 'alive' &&
-         alive_players.size == 1
+        player.id == TargetAssignment.lookup_assignment(player.id) &&
+        player.status == 'alive' &&
+        alive_players.size == 1
 
-         Game.destroy_all
-         Player.destroy_all
-         TargetAssignment.destroy_all
+        Game.destroy_all
+        Player.destroy_all
+        TargetAssignment.destroy_all
+
+        status 200
+      else
+        status 403
       end
     end
 

--- a/lib/assassin/server.rb
+++ b/lib/assassin/server.rb
@@ -328,9 +328,12 @@ module Assassin
          alive_players.size == 1 &&
          player.id == TargetAssignment.lookup_assignment(player.id)
 
+        # While Games and Players are interdependent (we have
+        # :destroy callbacks), TargetAssignment's have no
+        # dependents and can be deleted as a row
         Game.destroy_all
         Player.destroy_all
-        TargetAssignment.destroy_all
+        TargetAssignment.delete_all
 
         status 200
       else

--- a/lib/assassin/server.rb
+++ b/lib/assassin/server.rb
@@ -317,16 +317,16 @@ module Assassin
     # the named player is the last one standing
     post '/game/end' do
       req = JSON.parse(request.body.read)
-      username = req['username]']
+      username = req['username']
 
       player = Player.find_by(username: username)
-      alive_players = Player.all.select { |player| p.alive }
+      alive_players = Player.all.select { |player| player.alive }
 
       # Verify that this is the last player standing
       if player &&
-        player.id == TargetAssignment.lookup_assignment(player.id) &&
-        player.status == 'alive' &&
-        alive_players.size == 1
+         player.alive &&
+         alive_players.size == 1 &&
+         player.id == TargetAssignment.lookup_assignment(player.id)
 
         Game.destroy_all
         Player.destroy_all


### PR DESCRIPTION
We can now end a game, but only if the player requesting the end of the game is the last one standing. We check that they exist, are alive, are target-assigned to themselves, and are the only player that is still alive.

`/game/end` accepts `{ username: <username> }` and returns 200 upon successful state reset and 403 otherwise. 